### PR TITLE
Correction of ascending node crossing time  (ANX time)

### DIFF
--- a/src/s1reader/s1_annotation.py
+++ b/src/s1reader/s1_annotation.py
@@ -17,6 +17,7 @@ import numpy as np
 
 from isce3.core import speed_of_light
 from packaging import version
+from s1reader.s1_orbit import T_ORBIT
 from scipy.interpolate import InterpolatedUnivariateSpline, interp1d
 
 
@@ -1123,11 +1124,8 @@ class BurstEAP:
         # Perturbation phases (radians)
         phi = np.array([3.1495, -1.5655 , -3.1297, 4.7222])
 
-        # Orbital time period (seconds)
-        t_orb = (12*24*60*60) / 175.
-
         # Angular velocity (rad/sec)
-        worb = 2*np.pi / t_orb
+        worb = 2*np.pi / T_ORBIT
 
         # Evaluation of series
         h_t = h_0

--- a/src/s1reader/s1_burst_id.py
+++ b/src/s1reader/s1_burst_id.py
@@ -1,7 +1,7 @@
 import datetime
 from dataclasses import dataclass
 from typing import ClassVar
-
+from s1reader.s1_orbit import T_ORBIT
 import numpy as np
 
 
@@ -10,7 +10,7 @@ class S1BurstId:
     # Constants in Table 9-7 of Sentinel-1 SLC Detailed Algorithm Definition
     T_beam: ClassVar[float] = 2.758273  # interval of one burst [s]
     T_pre: ClassVar[float] = 2.299849  # Preamble time interval [s]
-    T_orb: ClassVar[float] = 12 * 24 * 3600 / 175  # Nominal orbit period [s]
+    T_orb: ClassVar[float] = T_ORBIT  # Nominal orbit period [s]
     track_number: int
     esa_burst_id: int
     subswath: str

--- a/src/s1reader/s1_orbit.py
+++ b/src/s1reader/s1_orbit.py
@@ -13,7 +13,7 @@ from xml.etree import ElementTree
 FMT = "%Y%m%dT%H%M%S"
 
 # Orbital period of Sentinel-1
-T_ORBIT = (12*86400.0) / 175.0
+T_ORBIT = (12 * 86400.0) / 175.0
 
 # Temporal margin to apply to the start time of a frame
 #  - To make sure that the event of ascending node crossong is

--- a/src/s1reader/s1_orbit.py
+++ b/src/s1reader/s1_orbit.py
@@ -12,6 +12,10 @@ from xml.etree import ElementTree
 # date format used in file names
 FMT = "%Y%m%dT%H%M%S"
 
+# Temporal margin to apply to the start time of a frame - To make sure that ANX is included when choosing the orbit file
+MARGIN_START_FRAME_SECONDS = (12*86400.0) / 175.0 + 60.0
+margin_start_time = datetime.timedelta(seconds=MARGIN_START_FRAME_SECONDS)
+
 # Scihub guest credential
 scihub_user = 'gnssguest'
 scihub_password = 'gnssguest'
@@ -40,6 +44,9 @@ def download_orbit(safe_file: str, orbit_dir: str):
 
     # Parse info from SAFE file name
     mission_id, _, start_time, end_time, _ = parse_safe_filename(safe_file)
+
+    # Apply margin to the start time
+    start_time = start_time - margin_start_time
 
     # Find precise orbit first
     orbit_dict = get_orbit_dict(mission_id, start_time,
@@ -292,6 +299,9 @@ def get_orbit_file_from_list(zip_path: str, orbit_file_list: list) -> str:
 
     # extract platform id, start and end times from swath file name
     mission_id, t_swath_start_stop = get_file_name_tokens(zip_path)
+
+    # Apply temporal margin to the start time of the frame
+    t_swath_start_stop[0] = t_swath_start_stop[0] - margin_start_time
 
     # initiate output
     orbit_file_final = ''

--- a/src/s1reader/s1_orbit.py
+++ b/src/s1reader/s1_orbit.py
@@ -301,6 +301,7 @@ def get_orbit_file_from_list(zip_path: str, orbit_file_list: list) -> str:
     mission_id, t_swath_start_stop = get_file_name_tokens(zip_path)
 
     # Apply temporal margin to the start time of the frame
+    # 1st element: start time, 2nd element: end time
     t_swath_start_stop[0] = t_swath_start_stop[0] - margin_start_time
 
     # initiate output

--- a/src/s1reader/s1_orbit.py
+++ b/src/s1reader/s1_orbit.py
@@ -12,11 +12,12 @@ from xml.etree import ElementTree
 # date format used in file names
 FMT = "%Y%m%dT%H%M%S"
 
-# Orbital period of Sentinel-1
+# Orbital period of Sentinel-1 in seconds:
+# 12 days * 86400.0 seconds/day, divided into 175 orbits
 T_ORBIT = (12 * 86400.0) / 175.0
 
 # Temporal margin to apply to the start time of a frame
-#  - To make sure that the event of ascending node crossong is
+#  to make sure that the ascending node crossing is
 #    included when choosing the orbit file
 margin_start_time = datetime.timedelta(seconds=T_ORBIT + 60.0)
 

--- a/src/s1reader/s1_orbit.py
+++ b/src/s1reader/s1_orbit.py
@@ -12,9 +12,13 @@ from xml.etree import ElementTree
 # date format used in file names
 FMT = "%Y%m%dT%H%M%S"
 
-# Temporal margin to apply to the start time of a frame - To make sure that ANX is included when choosing the orbit file
-MARGIN_START_FRAME_SECONDS = (12*86400.0) / 175.0 + 60.0
-margin_start_time = datetime.timedelta(seconds=MARGIN_START_FRAME_SECONDS)
+# Orbital period of Sentinel-1
+T_ORBIT = (12*86400.0) / 175.0
+
+# Temporal margin to apply to the start time of a frame
+#  - To make sure that the event of ascending node crossong is
+#    included when choosing the orbit file
+margin_start_time = datetime.timedelta(seconds=T_ORBIT + 60.0)
 
 # Scihub guest credential
 scihub_user = 'gnssguest'

--- a/src/s1reader/s1_reader.py
+++ b/src/s1reader/s1_reader.py
@@ -532,7 +532,8 @@ def get_track_burst_num(track_burst_num_file: str = esa_track_burst_id_file):
 
 def get_ascending_node_time_orbit(orbit_state_vector_list: ET,
                                   sensing_time: datetime.datetime,
-                                  anx_time_annotation: datetime.datetime=None):
+                                  anx_time_annotation: datetime.datetime=None,
+                                  search_length=None):
     '''
     Estimate the time of ascending node crossing from orbit
 
@@ -552,6 +553,9 @@ def get_ascending_node_time_orbit(orbit_state_vector_list: ET,
         - If it is `None`, then the orbit ANX time closest to (but no later than)
           the sensing time will be returned.
 
+    search_length: datetime.timedelta
+        Search length in time to crop the data in `orbit_state_vector_list`
+
     Returns
     -------
     _ : datetime.datetime
@@ -559,7 +563,8 @@ def get_ascending_node_time_orbit(orbit_state_vector_list: ET,
     '''
 
     # Crop the orbit information before 2 * (orbit period) of sensing time
-    search_length = datetime.timedelta(seconds=2 * T_ORBIT)
+    if search_length is None:
+        search_length = datetime.timedelta(seconds=2 * T_ORBIT)
     orbit_until_sensing_time = get_burst_orbit(sensing_time  - search_length,
                                                sensing_time,
                                                orbit_state_vector_list)
@@ -813,7 +818,7 @@ def burst_from_xml(annotation_path: str, orbit_path: str, tiff_path: str,
 
         # Calculate the difference in the two ANX times, and give
         # warning message when the difference is noticeable.
-        if not ascending_node_time_orbit is None:
+        if ascending_node_time_orbit is not None:
 
             diff_ascending_node_time_seconds = (
                 ascending_node_time_orbit - ascending_node_time_annotation).total_seconds()

--- a/src/s1reader/s1_reader.py
+++ b/src/s1reader/s1_reader.py
@@ -706,7 +706,8 @@ def burst_from_xml(annotation_path: str, orbit_path: str, tiff_path: str,
         tree = ET.parse(f)
 
         product_info_element = tree.find('generalAnnotation/productInformation')
-        azimuth_steer_rate = np.radians(float(product_info_element.find('azimuthSteeringRate').text))
+        azimuth_steer_rate =\
+            np.radians(float(product_info_element.find('azimuthSteeringRate').text))
         radar_freq = float(product_info_element.find('radarFrequency').text)
         range_sampling_rate = float(product_info_element.find('rangeSamplingRate').text)
         orbit_direction = product_info_element.find('pass').text
@@ -714,10 +715,12 @@ def burst_from_xml(annotation_path: str, orbit_path: str, tiff_path: str,
         image_info_element = tree.find('imageAnnotation/imageInformation')
         azimuth_time_interval = float(image_info_element.find('azimuthTimeInterval').text)
         slant_range_time = float(image_info_element.find('slantRangeTime').text)
-        ascending_node_time_annotation = as_datetime(image_info_element.find('ascendingNodeTime').text)
+        ascending_node_time_annotation =\
+            as_datetime(image_info_element.find('ascendingNodeTime').text)
         first_line_utc_time = as_datetime(image_info_element.find('productFirstLineUtcTime').text)
 
-        downlink_element = tree.find('generalAnnotation/downlinkInformationList/downlinkInformation')
+        downlink_element = tree.find('generalAnnotation/downlinkInformationList/'
+                                     'downlinkInformation')
         prf_raw_data = float(downlink_element.find('prf').text)
         rank = int(downlink_element.find('downlinkValues/rank').text)
         range_chirp_ramp_rate = float(downlink_element.find('downlinkValues/txPulseRampRate').text)
@@ -733,7 +736,9 @@ def burst_from_xml(annotation_path: str, orbit_path: str, tiff_path: str,
         poly_name = 'dataDcPolynomial'
         doppler_list = [parse_polynomial_element(x, poly_name) for x in doppler_list_element]
 
-        rng_processing_element = tree.find('imageAnnotation/processingInformation/swathProcParamsList/swathProcParams/rangeProcessing')
+        rng_processing_element = tree.find('imageAnnotation/processingInformation/'
+                                           'swathProcParamsList/swathProcParams/'
+                                           'rangeProcessing')
         rng_processing_bandwidth = float(rng_processing_element.find('processingBandwidth').text)
         range_window_type = str(rng_processing_element.find('windowType').text)
         range_window_coeff = float(rng_processing_element.find('windowCoefficient').text)
@@ -749,7 +754,8 @@ def burst_from_xml(annotation_path: str, orbit_path: str, tiff_path: str,
     # calculate the range at mid swath (mid of SM swath, mid of IW2 or mid of EW3)
     with open_method(iw2_annotation_path, 'r') as iw2_f:
         iw2_tree = ET.parse(iw2_f)
-        iw2_slant_range_time = float(iw2_tree.find('imageAnnotation/imageInformation/slantRangeTime').text)
+        iw2_slant_range_time =\
+            float(iw2_tree.find('imageAnnotation/imageInformation/slantRangeTime').text)
         iw2_n_samples = int(iw2_tree.find('swathTiming/samplesPerBurst').text)
         iw2_starting_range = iw2_slant_range_time * isce3.core.speed_of_light / 2
         iw2_mid_range = iw2_starting_range + 0.5 * iw2_n_samples * range_pxl_spacing

--- a/src/s1reader/s1_reader.py
+++ b/src/s1reader/s1_reader.py
@@ -28,8 +28,8 @@ from s1reader.s1_annotation import ProductAnnotation, NoiseAnnotation,\
 from s1reader.s1_burst_slc import Doppler, Sentinel1BurstSlc
 from s1reader.s1_burst_id import S1BurstId
 from s1reader.s1_orbit import T_ORBIT
-# Tolerance of the ascending node crossing (ANX) time
-ANX_TIME_TOLERANCE = 1.0
+# Tolerance of the ascending node crossing time
+ASCENDING_NODE_TIME_TOLERANCE = 1.0
 esa_track_burst_id_file = f"{os.path.dirname(os.path.realpath(__file__))}/data/sentinel1_track_burst_id.txt"
 
 # TODO evaluate if it make sense to combine below into a class
@@ -531,7 +531,7 @@ def get_track_burst_num(track_burst_num_file: str = esa_track_burst_id_file):
 
 def get_anx_time_orbit(osv_list: ET, sensing_time: datetime.datetime):
     '''
-    Estimate the time of ascending node crossing (ANX) from orbit
+    Estimate the time of ascending node crossing from orbit
 
     Parameters
     ----------
@@ -543,7 +543,7 @@ def get_anx_time_orbit(osv_list: ET, sensing_time: datetime.datetime):
     Returns
     -------
     _ : datetime.datetime
-        Ascending node crossing (ANX) time calculated from orbit
+        Ascending node crossing time calculated from orbit
     '''
 
     # Crop the orbit information before 2 * (orbit period) of sensing time
@@ -756,15 +756,15 @@ def burst_from_xml(annotation_path: str, orbit_path: str, tiff_path: str,
         orbit_tree = ET.parse(orbit_path)
         orbit_state_vector_list = orbit_tree.find('Data_Block/List_of_OSVs')
 
-        # Calculate ascending node crossing (ANX) time from orbit;
+        # Calculate ascending node crossing time from orbit;
         # compare with the info from annotation
         ascending_node_time_orbit = get_anx_time_orbit(
             orbit_state_vector_list, first_line_utc_time)
         diff_anx_time_seconds = (
             ascending_node_time_orbit - ascending_node_time_annotation).total_seconds()
-        if abs(diff_anx_time_seconds) > ANX_TIME_TOLERANCE:
+        if abs(diff_anx_time_seconds) > ASCENDING_NODE_TIME_TOLERANCE:
             warnings.warn('ascending node time error larger than '
-                          f'{ANX_TIME_TOLERANCE} seconds was detected: '
+                          f'{ASCENDING_NODE_TIME_TOLERANCE} seconds was detected: '
                           f'Error = {diff_anx_time_seconds} seconds.')
         ascending_node_time = ascending_node_time_orbit
 

--- a/src/s1reader/s1_reader.py
+++ b/src/s1reader/s1_reader.py
@@ -575,25 +575,28 @@ def get_ascending_node_time_orbit(orbit_state_vector_list: ET, sensing_time: dat
     # detect the ascending node crossing
     iterator_z_time = zip(orbit_z_vec, orbit_z_vec[1:], orbit_time_vec)
     for index_z, (z_prev, z, _) in enumerate(iterator_z_time):
-        if z_prev < 0 <= z:
-            # Extract z coords. and time for interpolation
-            index_from = max(index_z - 3, 0)
-            index_to = min(index_z + 3, len(orbit_z_vec))
-            z_around_crossing = orbit_z_vec[index_from : index_to]
-            time_around_crossing = orbit_time_vec[index_from : index_to]
+        # Check if ascending node crossing has taken place;
+        if not z_prev < 0 <= z:
+            continue
 
-            # Set up spline interpolator and interpolate the time when z is equal to 0.0
-            interpolator_time = InterpolatedUnivariateSpline(z_around_crossing,
-                                                             time_around_crossing,
-                                                             k=1)
-            t_interp = interpolator_time(0.0)
+        # Extract z coords. and time for interpolation
+        index_from = max(index_z - 3, 0)
+        index_to = min(index_z + 3, len(orbit_z_vec))
+        z_around_crossing = orbit_z_vec[index_from : index_to]
+        time_around_crossing = orbit_time_vec[index_from : index_to]
 
-            # Convert the interpolated time into datetime
-            # Add the ascending node crossing time if it's before the sensing time
-            datetime_ascending_crossing = (datetime_orbit_ref
-                                           + datetime.timedelta(seconds=float(t_interp)))
-            if datetime_ascending_crossing < sensing_time:
-                datetime_ascending_node_crossing_list.append(datetime_ascending_crossing)
+        # Set up spline interpolator and interpolate the time when z is equal to 0.0
+        interpolator_time = InterpolatedUnivariateSpline(z_around_crossing,
+                                                            time_around_crossing,
+                                                            k=1)
+        t_interp = interpolator_time(0.0)
+
+        # Convert the interpolated time into datetime
+        # Add the ascending node crossing time if it's before the sensing time
+        datetime_ascending_crossing = (datetime_orbit_ref
+                                        + datetime.timedelta(seconds=float(t_interp)))
+        if datetime_ascending_crossing < sensing_time:
+            datetime_ascending_node_crossing_list.append(datetime_ascending_crossing)
 
     if len(datetime_ascending_node_crossing_list) == 0:
         warnings.warn('Cannot detect ascending node crossings from the orbit information provided.')

--- a/src/s1reader/s1_reader.py
+++ b/src/s1reader/s1_reader.py
@@ -573,7 +573,7 @@ def get_ascending_node_time_orbit(orbit_state_vector_list: ET, sensing_time: dat
 
     # Iterate through the z coordinate in orbit object to
     # detect the ascending node crossing
-    iterator_z_time = zip(orbit_z_vec, orbit_z_vec[1,:], orbit_time_vec)
+    iterator_z_time = zip(orbit_z_vec, orbit_z_vec[1:], orbit_time_vec)
     for index_z, (z_prev, z, _) in enumerate(iterator_z_time):
         if z_prev < 0 <= z:
             # Extract z coords. and time for interpolation
@@ -594,7 +594,6 @@ def get_ascending_node_time_orbit(orbit_state_vector_list: ET, sensing_time: dat
                                            + datetime.timedelta(seconds=float(t_interp)))
             if datetime_ascending_crossing < sensing_time:
                 datetime_ascending_node_crossing_list.append(datetime_ascending_crossing)
-        z_prev = z
 
     if len(datetime_ascending_node_crossing_list) == 0:
         warnings.warn('Cannot detect ascending node crossings from the orbit information provided.')

--- a/src/s1reader/s1_reader.py
+++ b/src/s1reader/s1_reader.py
@@ -689,7 +689,7 @@ def burst_from_xml(annotation_path: str, orbit_path: str, tiff_path: str,
         image_info_element = tree.find('imageAnnotation/imageInformation')
         azimuth_time_interval = float(image_info_element.find('azimuthTimeInterval').text)
         slant_range_time = float(image_info_element.find('slantRangeTime').text)
-        ascending_node_time = as_datetime(image_info_element.find('ascendingNodeTime').text)
+        ascending_node_time_annotation = as_datetime(image_info_element.find('ascendingNodeTime').text)
 
         downlink_element = tree.find('generalAnnotation/downlinkInformationList/downlinkInformation')
         prf_raw_data = float(downlink_element.find('prf').text)
@@ -735,15 +735,20 @@ def burst_from_xml(annotation_path: str, orbit_path: str, tiff_path: str,
 
         # Calculate ascending node crossing (ANX) time from orbit;
         # compare with the info from annotation
-        anx_time_orbit = get_anx_time_orbit(orbit_state_vector_list, ascending_node_time)
-        diff_anx_time_seconds = (anx_time_orbit - ascending_node_time).total_seconds()
+        ascending_node_time_orbit = get_anx_time_orbit(
+            orbit_state_vector_list, ascending_node_time_annotation)
+        diff_anx_time_seconds = (
+            ascending_node_time_orbit - ascending_node_time_annotation).total_seconds()
         if abs(diff_anx_time_seconds) > ANX_TIME_TOLERANCE:
-            warnings.warn('Ascending node cross time is larger than '
-                          f'{ANX_TIME_TOLERANCE} seconds. '
-                          'Using the time from orbit.')
-            ascending_node_time = anx_time_orbit
+            warnings.warn('ascending node time error larger than '
+                          f'{ANX_TIME_TOLERANCE} seconds was detected: '
+                          f'Error = {diff_anx_time_seconds} seconds.')
+        ascending_node_time = ascending_node_time_orbit
 
     else:
+        warnings.warn('Orbit file was not provided. '
+                      'Using the ascending node time from annotation.')
+        ascending_node_time = ascending_node_time_annotation
         orbit_state_vector_list = []
 
     # load individual burst

--- a/src/s1reader/s1_reader.py
+++ b/src/s1reader/s1_reader.py
@@ -532,17 +532,17 @@ def get_anx_time_orbit(osv_list:list, anx_time_annotation: datetime.datetime, ma
     '''
     Estimate the time of ascending node crossing (ANX) from orbit
 
-    parameters
+    Parameters
     ----------
     osv_list: list
         Orbit state vectors as list
-    anx_time_annotatiion: datetime.datetime
-        ANX time read from annotation
+    anx_time_annotation: datetime.datetime
+        Ascending node crossing (ANX) time estimated from annotation
 
-    returns
+    Returns
     -------
     _ : datetime.datetime
-        ANX time calculated from orbit
+        Ascending node crossing (ANX) time calculated from orbit
     '''
 
     margin_anx = datetime.timedelta(seconds=margin_anx_sec)
@@ -732,7 +732,7 @@ def burst_from_xml(annotation_path: str, orbit_path: str, tiff_path: str,
         orbit_tree = ET.parse(orbit_path)
         osv_list = orbit_tree.find('Data_Block/List_of_OSVs')
 
-        # Calculate ANX time from orbit; compare with the info from annotation
+        # Calculate ascending node crossing (ANX) time from orbit; compare with the info from annotation
         anx_time_orbit = get_anx_time_orbit(osv_list, ascending_node_time)
         diff_anx_time_seconds = (anx_time_orbit - ascending_node_time).total_seconds()
         if abs(diff_anx_time_seconds) > 1.0:

--- a/src/s1reader/s1_reader.py
+++ b/src/s1reader/s1_reader.py
@@ -28,7 +28,8 @@ from s1reader.s1_annotation import ProductAnnotation, NoiseAnnotation,\
 from s1reader.s1_burst_slc import Doppler, Sentinel1BurstSlc
 from s1reader.s1_burst_id import S1BurstId
 from s1reader.s1_orbit import T_ORBIT
-# Tolerance of the ascending node crossing time
+
+# Tolerance of the ascending node crossing time in seconds
 ASCENDING_NODE_TIME_TOLERANCE = 1.0
 esa_track_burst_id_file = f"{os.path.dirname(os.path.realpath(__file__))}/data/sentinel1_track_burst_id.txt"
 
@@ -537,7 +538,7 @@ def get_ascending_node_time_orbit(orbit_state_vector_list: ET, sensing_time: dat
     ----------
     orbit_state_vector_list: ET
         XML elements that points to the list of orbit information.
-        each elements in the parameter contains the information below:
+        Each element should contain the information below:
         TAI, UTC, UT1, Absolute_Orbit, X, Y, Z, VX, VY, VZ,Quality
 
     sensing_time: datetime.datetime
@@ -555,7 +556,7 @@ def get_ascending_node_time_orbit(orbit_state_vector_list: ET, sensing_time: dat
                                                sensing_time,
                                                orbit_state_vector_list)
 
-    # Convert ISCE3 oribt object's reference datetime into python object
+    # Convert the ISCE3 orbit reference datetime into a python object
     datetime_orbit_ref = datetime.datetime(
         orbit_until_sensing_time.reference_epoch.year,
         orbit_until_sensing_time.reference_epoch.month,
@@ -563,8 +564,8 @@ def get_ascending_node_time_orbit(orbit_state_vector_list: ET, sensing_time: dat
     datetime_orbit_ref += datetime.timedelta(
         seconds=orbit_until_sensing_time.reference_epoch.seconds_of_day())
 
-    # detect the event of ascending node crossing from the cropped orbit info.
-    # Algorithm inspirates by Scott Staniewicz's PR in the link below:
+    # Detect the event of ascending node crossing from the cropped orbit info.
+    # The algorithm was inspired by Scott Staniewicz's PR in the link below:
     # https://github.com/opera-adt/s1-reader/pull/120/
     datetime_ascending_node_crossing_list = []
     orbit_time_vec = np.array(orbit_until_sensing_time.time)

--- a/src/s1reader/s1_reader.py
+++ b/src/s1reader/s1_reader.py
@@ -30,7 +30,7 @@ from s1reader.s1_burst_id import S1BurstId
 from s1reader.s1_orbit import T_ORBIT
 
 # Tolerance of the ascending node crossing time in seconds
-ASCENDING_NODE_TIME_TOLERANCE = 1.0
+ASCENDING_NODE_TIME_TOLERANCE_IN_SEC = 1.0
 esa_track_burst_id_file = f"{os.path.dirname(os.path.realpath(__file__))}/data/sentinel1_track_burst_id.txt"
 
 # TODO evaluate if it make sense to combine below into a class
@@ -790,9 +790,9 @@ def burst_from_xml(annotation_path: str, orbit_path: str, tiff_path: str,
             # Give warning message when the difference is noticeable.
             diff_ascending_node_time_seconds = (
                 ascending_node_time_orbit - ascending_node_time_annotation).total_seconds()
-            if abs(diff_ascending_node_time_seconds) > ASCENDING_NODE_TIME_TOLERANCE:
+            if abs(diff_ascending_node_time_seconds) > ASCENDING_NODE_TIME_TOLERANCE_IN_SEC:
                 warnings.warn('ascending node time error larger than '
-                            f'{ASCENDING_NODE_TIME_TOLERANCE} seconds was detected: '
+                            f'{ASCENDING_NODE_TIME_TOLERANCE_IN_SEC} seconds was detected: '
                             f'Error = {diff_ascending_node_time_seconds} seconds.')
 
             ascending_node_time = ascending_node_time_orbit

--- a/src/s1reader/s1_reader.py
+++ b/src/s1reader/s1_reader.py
@@ -1125,7 +1125,7 @@ def _burst_from_safe_dir(safe_dir_path: str, id_str: str, orbit_path: str,
     else:
         msg = f'measurement directory NOT found in {safe_dir_path}'
         msg += ', continue with metadata only.'
-        print(msg)
+        warnings.warn(msg)
         f_tiff = ''
 
     bursts = burst_from_xml(f_annotation, orbit_path, f_tiff, iw2_f_annotation,

--- a/src/s1reader/s1_reader.py
+++ b/src/s1reader/s1_reader.py
@@ -529,14 +529,17 @@ def get_track_burst_num(track_burst_num_file: str = esa_track_burst_id_file):
     return track_burst_num
 
 
-def get_anx_time_orbit(osv_list: ET, sensing_time: datetime.datetime):
+def get_ascending_node_time_orbit(orbit_state_vector_list: ET, sensing_time: datetime.datetime):
     '''
     Estimate the time of ascending node crossing from orbit
 
     Parameters
     ----------
-    osv_list: ET
-        Orbit state vectors as XML Element Tree
+    orbit_state_vector_list: ET
+        XML elements that points to the list of orbit information.
+        each elements in the parameter contains the information below:
+        TAI, UTC, UT1, Absolute_Orbit, X, Y, Z, VX, VY, VZ,Quality
+
     sensing_time: datetime.datetime
         Sensing time of the data
 
@@ -550,7 +553,7 @@ def get_anx_time_orbit(osv_list: ET, sensing_time: datetime.datetime):
     search_length = datetime.timedelta(seconds=2 * T_ORBIT)
     orbit_until_sensing_time = get_burst_orbit(sensing_time  - search_length,
                                                sensing_time,
-                                               osv_list)
+                                               orbit_state_vector_list)
 
     # Convert ISCE3 oribt object's reference datetime into python object
     datetime_orbit_ref = datetime.datetime(
@@ -758,14 +761,14 @@ def burst_from_xml(annotation_path: str, orbit_path: str, tiff_path: str,
 
         # Calculate ascending node crossing time from orbit;
         # compare with the info from annotation
-        ascending_node_time_orbit = get_anx_time_orbit(
+        ascending_node_time_orbit = get_ascending_node_time_orbit(
             orbit_state_vector_list, first_line_utc_time)
-        diff_anx_time_seconds = (
+        diff_ascending_node_time_seconds = (
             ascending_node_time_orbit - ascending_node_time_annotation).total_seconds()
-        if abs(diff_anx_time_seconds) > ASCENDING_NODE_TIME_TOLERANCE:
+        if abs(diff_ascending_node_time_seconds) > ASCENDING_NODE_TIME_TOLERANCE:
             warnings.warn('ascending node time error larger than '
                           f'{ASCENDING_NODE_TIME_TOLERANCE} seconds was detected: '
-                          f'Error = {diff_anx_time_seconds} seconds.')
+                          f'Error = {diff_ascending_node_time_seconds} seconds.')
         ascending_node_time = ascending_node_time_orbit
 
     else:

--- a/src/s1reader/s1_reader.py
+++ b/src/s1reader/s1_reader.py
@@ -573,9 +573,9 @@ def get_ascending_node_time_orbit(orbit_state_vector_list: ET, sensing_time: dat
 
     # Iterate through the z coordinate in orbit object to
     # detect the ascending node crossing
-    z_prev = None
-    for index_z, z in enumerate(orbit_z_vec):
-        if z_prev is not None and (z_prev < 0 <= z):
+    iterator_z_time = zip(orbit_z_vec, orbit_z_vec[1,:], orbit_time_vec)
+    for index_z, (z_prev, z, _) in enumerate(iterator_z_time):
+        if z_prev < 0 <= z:
             # Extract z coords. and time for interpolation
             index_from = max(index_z - 3, 0)
             index_to = min(index_z + 3, len(orbit_z_vec))

--- a/tests/test_bursts.py
+++ b/tests/test_bursts.py
@@ -4,7 +4,6 @@ import isce3
 import numpy as np
 
 
-
 def test_burst(bursts):
     last_valid_lines = [1487, 1489, 1489, 1490, 1487, 1488, 1488, 1489, 1488]
     first_valid_lines = [28, 27, 27, 27, 28, 28, 28, 27, 28]

--- a/tests/test_orbit.py
+++ b/tests/test_orbit.py
@@ -1,17 +1,22 @@
+'''
+Unit tests for orbit
+'''
+
 import datetime
+import zipfile
 
 import isce3
+import lxml.etree as ET
 import numpy as np
 from shapely.geometry import Point
 
-from s1reader.s1_orbit import (
-    get_orbit_file_from_dir, get_ascending_node_crossings, get_closest_ascending_node
-)
-from s1reader.s1_burst_id import S1BurstId
-from s1reader import load_bursts
-
+from s1reader.s1_orbit import get_orbit_file_from_dir
+from s1reader.s1_reader import as_datetime, get_ascending_node_time_orbit
 
 def test_get_orbit_file(test_paths):
+    '''
+    Unit test for `get_orbit_file_from_dir`
+    '''
     orbit_file = get_orbit_file_from_dir(test_paths.safe, test_paths.orbit_dir)
 
     expected_orbit_path = f'{test_paths.orbit_dir}/{test_paths.orbit_file}'
@@ -19,6 +24,9 @@ def test_get_orbit_file(test_paths):
 
 
 def test_get_orbit_file_multi_mission(tmp_path):
+    '''
+    Unit test for `get_orbit_file_from_dir` in case of multiple SAFE .zip files
+    '''
     orbit_a = tmp_path / "S1A_OPER_AUX_POEORB_OPOD_20210314T131617_V20191007T225942_20191009T005942.EOF"
     orbit_a.write_text("")
     orbit_b = tmp_path / "S1B_OPER_AUX_POEORB_OPOD_20210304T232500_V20191007T225942_20191009T005942.EOF"
@@ -37,6 +45,9 @@ def test_get_orbit_file_multi_mission(tmp_path):
 
 
 def test_orbit_datetime(bursts):
+    '''
+    Unit test for datetimes in the orbit file
+    '''
     # pad in seconds used in orbit_reader
     pad = datetime.timedelta(seconds=60)
     for burst in bursts:
@@ -60,23 +71,39 @@ def test_orbit_datetime(bursts):
                                      rdr_grid.lookside, dop,
                                      rdr_grid.wavelength, dem)
         pnt = Point(np.degrees(llh[0]), np.degrees(llh[1]))
-        assert(burst.border[0].contains(pnt))
+        assert burst.border[0].contains(pnt)
 
 
-def test_get_ascending_node_crossings(test_paths):
-    orbit_file = get_orbit_file_from_dir(test_paths.safe, test_paths.orbit_dir)
-    anx_times = get_ascending_node_crossings(orbit_file)
-    # Make sure each orbit is approx. the right number of seconds
-    anx_time_diffs = np.diff(anx_times)
-    # Compare to nominal orbit time, S1BurstId.T_orb 
-    for time_diff in anx_time_diffs:
-        assert np.isclose(time_diff.total_seconds(), S1BurstId.T_orb, atol=0.5)
+def test_anx_time(test_paths):
+    '''
+    Compute ascending node crossing (ANX) time from orbit,
+    and compare it with annotation ANX time.
+    '''
 
+    with zipfile.ZipFile(test_paths.safe, 'r') as safe_zip:
+        # find the 1st .xml
+        filename = ''
+        for filename in safe_zip.namelist():
+            if 'annotation/s1' in filename and filename.endswith('-001.xml'):
+                break
 
-def test_get_closest_ascending_node(test_paths):
-    orbit_file = get_orbit_file_from_dir(test_paths.safe, test_paths.orbit_dir)
-    burst = load_bursts(test_paths.safe, orbit_file, 1)[0]
-    # TODO: if we change how load_bursts gets the ANX time, we'll need to parse the
-    # ANX time here from the zip file. we should move the function currently in s1_reader to the orbit module
-    anx_time = get_closest_ascending_node(orbit_file, test_paths.safe)
-    assert abs(burst.ascending_node_time - anx_time) < datetime.timedelta(seconds=0.5)
+        with safe_zip.open(filename, 'r') as f:
+            tree = ET.parse(f)
+            image_info_element = tree.find('imageAnnotation/imageInformation')
+            ascending_node_time_annotation =\
+                as_datetime(image_info_element.find('ascendingNodeTime').text)
+            first_line_utc_time = as_datetime(
+                image_info_element.find('productFirstLineUtcTime').text)
+
+    orbit_path = f'{test_paths.orbit_dir}/{test_paths.orbit_file}'
+    orbit_tree = ET.parse(orbit_path)
+    orbit_state_vector_list = orbit_tree.find('Data_Block/List_of_OSVs')
+
+    ascending_node_time_orbit = get_ascending_node_time_orbit(
+                                            orbit_state_vector_list,
+                                            first_line_utc_time,
+                                            ascending_node_time_annotation)
+    diff_ascending_node_time_seconds = (ascending_node_time_orbit
+                                        - ascending_node_time_annotation).total_seconds()
+
+    assert abs(diff_ascending_node_time_seconds) < 0.5

--- a/tests/test_orbit.py
+++ b/tests/test_orbit.py
@@ -65,8 +65,8 @@ def test_orbit_datetime(bursts):
 
 def test_get_ascending_node_crossings(test_paths):
     orbit_file = get_orbit_file_from_dir(test_paths.safe, test_paths.orbit_dir)
-    # pad in seconds used in orbit_reader
     anx_times = get_ascending_node_crossings(orbit_file)
+    # Make sure each orbit is approx. the right number of seconds
     anx_time_diffs = np.diff(anx_times)
     # Compare to nominal orbit time, S1BurstId.T_orb 
     for time_diff in anx_time_diffs:
@@ -75,7 +75,8 @@ def test_get_ascending_node_crossings(test_paths):
 
 def test_get_closest_ascending_node(test_paths):
     orbit_file = get_orbit_file_from_dir(test_paths.safe, test_paths.orbit_dir)
-    # pad in seconds used in orbit_reader
     burst = load_bursts(test_paths.safe, orbit_file, 1)[0]
+    # TODO: if we change how load_bursts gets the ANX time, we'll need to parse the
+    # ANX time here from the zip file. we should move the function currently in s1_reader to the orbit module
     anx_time = get_closest_ascending_node(orbit_file, test_paths.safe)
     assert abs(burst.ascending_node_time - anx_time) < datetime.timedelta(seconds=0.5)

--- a/tests/test_orbit.py
+++ b/tests/test_orbit.py
@@ -4,7 +4,11 @@ import isce3
 import numpy as np
 from shapely.geometry import Point
 
-from s1reader.s1_orbit import get_orbit_file_from_dir
+from s1reader.s1_orbit import (
+    get_orbit_file_from_dir, get_ascending_node_crossings, get_closest_ascending_node
+)
+from s1reader.s1_burst_id import S1BurstId
+from s1reader import load_bursts
 
 
 def test_get_orbit_file(test_paths):
@@ -57,3 +61,21 @@ def test_orbit_datetime(bursts):
                                      rdr_grid.wavelength, dem)
         pnt = Point(np.degrees(llh[0]), np.degrees(llh[1]))
         assert(burst.border[0].contains(pnt))
+
+
+def test_get_ascending_node_crossings(test_paths):
+    orbit_file = get_orbit_file_from_dir(test_paths.safe, test_paths.orbit_dir)
+    # pad in seconds used in orbit_reader
+    anx_times = get_ascending_node_crossings(orbit_file)
+    anx_time_diffs = np.diff(anx_times)
+    # Compare to nominal orbit time, S1BurstId.T_orb 
+    for time_diff in anx_time_diffs:
+        assert np.isclose(time_diff.total_seconds(), S1BurstId.T_orb, atol=0.5)
+
+
+def test_get_closest_ascending_node(test_paths):
+    orbit_file = get_orbit_file_from_dir(test_paths.safe, test_paths.orbit_dir)
+    # pad in seconds used in orbit_reader
+    burst = load_bursts(test_paths.safe, orbit_file, 1)[0]
+    anx_time = get_closest_ascending_node(orbit_file, test_paths.safe)
+    assert abs(burst.ascending_node_time - anx_time) < datetime.timedelta(seconds=0.5)


### PR DESCRIPTION
It has came into our attention that some of Sentinel-1 data has noticeable error in ANX time, which can cause incorrect computation of burst ID. More details about the issue can be found in #117.
This PR is to fix the issue by calculating the ANX time from orbit data. The screenshot below is the RTC outputs (VV polarization) before and after the ANX time correction.

<img width="2121" alt="Screenshot 2023-06-07 at 17 04 24" src="https://github.com/opera-adt/s1-reader/assets/27862199/56a1c7ce-1d07-4a60-afb3-e8586769d231">
Figure 1. Before the correction



.
<img width="2126" alt="Screenshot 2023-06-07 at 17 06 27" src="https://github.com/opera-adt/s1-reader/assets/27862199/12767e39-fe3d-4215-9848-9af00d764d9c">
Figure 2. After the correction


Information about the test dataset above:
On and around [Grenada](https://en.wikipedia.org/wiki/Grenada) (North of Venezuela)
`S1B_IW_SLC__1SDV_20211014T095918_20211014T095945_029130_0379DF_B302.zip`
`S1B_OPER_AUX_POEORB_OPOD_20211103T112606_V20211013T225942_20211015T005942.EOF`