### PR TITLE
Release updates

### DIFF
--- a/.circleci/freeze-deps.sh
+++ b/.circleci/freeze-deps.sh
@@ -5,7 +5,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-readonly HELP='usage: ./create-lockfile.sh ENVFILE > specfile.txt
+readonly HELP='usage: ./freeze-deps.sh ENVFILE > specfile.txt
 
 Create a conda lockfile from an environment YAML file for reproducible
 environments.

--- a/.circleci/freeze-deps.sh
+++ b/.circleci/freeze-deps.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
-docker run -v "$PWD:/mnt" -w /mnt --rm -it continuumio/miniconda3 bash -c '\
+docker run --network=host -v "$PWD:/mnt" -w /mnt --rm -it continuumio/miniconda3 bash -c '\
     conda config --add channels conda-forge && \
     conda config --remove channels defaults && \
     conda update -y conda && \
-    conda install -y --file environment.yaml && conda list --explicit > specfile.txt'
+    conda env create --file environment.yaml && conda list --explicit > specfile.txt'

--- a/.circleci/freeze-deps.sh
+++ b/.circleci/freeze-deps.sh
@@ -1,6 +1,46 @@
-#!/bin/sh
-docker run --network=host -v "$PWD:/mnt" -w /mnt --rm -it continuumio/miniconda3 bash -c '\
-    conda config --add channels conda-forge && \
-    conda config --remove channels defaults && \
-    conda update -y conda && \
-    conda env create --file environment.yaml && conda list --explicit > specfile.txt'
+#!/usr/bin/env bash
+
+# Enable common error handling options.
+set -o errexit
+set -o nounset
+set -o pipefail
+
+readonly HELP='usage: ./create-lockfile.sh ENVFILE > specfile.txt
+
+Create a conda lockfile from an environment YAML file for reproducible
+environments.
+
+positional arguments:
+ENVFILE     a YAML file containing package specifications
+
+options:
+-h, --help  show this help message and exit
+'
+
+main() {
+    # Get absolute path of input YAML file.
+    local ENVFILE
+    ENVFILE=$(realpath "$1")
+
+    # Get concretized package list.
+    local PKGLIST
+    PKGLIST=$(docker run --network=host \
+        -v "$ENVFILE:/tmp/environment.yml:ro" --rm \
+        mambaorg/micromamba:1.1.0 bash -c '\
+            micromamba install -y -n base -f /tmp/environment.yml > /dev/null && \
+            micromamba env export --explicit')
+
+    # Sort packages alphabetically.
+    # (The first 4 lines are assumed to be header lines and ignored.)
+    echo "$PKGLIST" | (sed -u 4q; sort)
+}
+
+if [[ "${1-}" =~ ^-*h(elp)?$ ]]; then
+    echo "$HELP"
+elif [[ "$#" -ne 1 ]]; then
+    echo 'Illegal number of parameters' >&2
+    echo "$HELP"
+    exit 1
+else
+    main "$@"
+fi

--- a/.circleci/freeze-deps.sh
+++ b/.circleci/freeze-deps.sh
@@ -3,4 +3,4 @@ docker run -v "$PWD:/mnt" -w /mnt --rm -it continuumio/miniconda3 bash -c '\
     conda config --add channels conda-forge && \
     conda config --remove channels defaults && \
     conda update -y conda && \
-    conda install -y -c conda-forge isce3=0.8 build setuptools pytest isce3 shapely lxml && conda list --explicit > specfile.txt'
+    conda install -y --file environment.yaml && conda list --explicit > specfile.txt'

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,8 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2022 California Institute of Technology (“Caltech”).
+   U.S. Government sponsorship acknowledged.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -1,21 +1,29 @@
-## s1-reader
+# s1-reader
 
 A package to read Sentinel-1 data into the ISCE3-compatible burst class.
 
-### Features
+## Features
 
-+ Create ISCE3-compatible Sentinel1 burst class given:
+Create ISCE3-compatible Sentinel1 burst class given:
 
-  - S1 SAFE
-  - subswath index
-  - polarization
-  - path to orbit directory
+- S1 SAFE
+- subswath index
+- polarization
+- path to orbit directory
 
-+ Monotonically increasing bursts IDs.
+Creates a Burst ID based on [ESA's published burst ID maps](https://sentinel.esa.int/web/sentinel/-/publication-of-brust-id-maps-for-copernicus-sentinel-1/1.1).
 
 🚨 This toolbox is still in **pre-alpha** stage and undergoing **rapid development**. 🚨 
 
-### Install
+## Install
+
+`s1reader` is available to install via `conda-forge`:
+
+```bash
+conda install -c conda-forge s1reader
+```
+
+### Installing for development
 
 1. Download source code:
 
@@ -26,17 +34,17 @@ git clone https://github.com/opera-adt/s1-reader.git
 2. Install dependencies:
 
 ```bash
-conda install -c conda-forge --file s1-reader/requirements.txt
+conda env create --file s1-reader/requirements.txt
 ```
 
-3. Install `s1-reader` via pip:
+3. Install `s1reader` via pip:
 
 ```bash
 # run "pip install -e" to install in development mode
-python -m pip install ./s1-reader
+python -m pip install -e ./s1-reader
 ```
 
-### Usage
+## Usage
 
 The following sample code demonstrates how to process a single burst from a S1 SAFE zip:
 
@@ -56,7 +64,7 @@ bursts = s1reader.load_bursts(zip_path, orbit_path, swath_num, pol)
 burst_ids = [x.burst_id for x in bursts]
 ```
 
-### License
+## License
 
 **Copyright (c) 2021** California Institute of Technology (“Caltech”). U.S. Government sponsorship acknowledged.
 

--- a/README.md
+++ b/README.md
@@ -29,19 +29,20 @@ conda install -c conda-forge s1reader
 
 ```bash
 git clone https://github.com/opera-adt/s1-reader.git
+cd s1-reader
 ```
 
 2. Install dependencies:
 
 ```bash
-conda env create --file s1-reader/requirements.txt
+conda env create --file environment.yaml
 ```
 
 3. Install `s1reader` via pip:
 
 ```bash
 # run "pip install -e" to install in development mode
-python -m pip install -e ./s1-reader
+python -m pip install -e .
 ```
 
 ## Usage

--- a/environment.yaml
+++ b/environment.yaml
@@ -1,11 +1,12 @@
 name: s1reader
 channels:
-  - defaults
   - conda-forge
 dependencies:
-  - numpy
-  - gdal
-  - isce3
-  - packaging
-  - requests
-  - shapely
+  - python>=3.8
+  - numpy>=1.20
+  - gdal>=3.0
+  - isce3>=0.13
+  - packaging>=21.0
+  - requests>=2.0
+  - shapely>=1.8
+  - lxml>=4.8

--- a/src/s1reader/version.py
+++ b/src/s1reader/version.py
@@ -1,11 +1,10 @@
 # release history
-
 import collections
-
 
 # release history
 Tag = collections.namedtuple('Tag', 'version date')
 release_history = (
+    Tag('0.2.0', '2023-07-25'),
     Tag('0.1.7', '2023-05-09'),
     Tag('0.1.6', '2023-03-22'),
     Tag('0.1.5', '2022-12-21'),


### PR DESCRIPTION
- bump to v0.2.0
- Various fixes for environments in preparation to put up on conda forge (which i will do after this is merged and the release is created)
- I switched the environment freezing script to the one @gmgunter made for `dophin`. It runs faster from using micromamba, but the only functional difference is that it pins to a specific conda hash for each package.  I didn't change the specfile, as I didn't want to mess something up if seongsu is already working on the docker preparation elsewhere.