### PR TITLE
remove importlib_resources from `install_requires`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,6 @@ include_package_data = True
 python_requires = >=3.8
 install_requires =
     setuptools
-    importlib_resources
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
Not sure why this was added, since [importlib.resources was available in python3.7](https://docs.python.org/3/library/importlib.resources.html) and we were never supporting older versions than that. We also dont seem to ever mention this package in the code.