### PR TITLE
s1_info.py to take care of antimeridian-crossing

### DIFF
--- a/src/s1reader/s1_info.py
+++ b/src/s1reader/s1_info.py
@@ -112,6 +112,11 @@ def _bounds_from_preview(safe_path: Union[Path, str]) -> list[float]:
     point_str = list(elem.text for elem in root.iter("coordinates"))[0]
     coords = [p.split(",") for p in point_str.split()]
     lons, lats = zip(*[(float(lon), float(lat)) for lon, lat in coords])
+
+    if max(lons) - min(lons) > 180.0:
+        # Antimeridian crossing detected
+        lons = [lon + (lon < 0) * 360.0 for lon in lons]
+
     return [min(lons), min(lats), max(lons), max(lats)]
 
 


### PR DESCRIPTION
This PR is to take care of the case that the S1 frame's area crosses antimeridian when `s1_info.py` computes the bounding box. The fix is based on the code [here](https://github.com/nasa/opera-sds-pcm/pull/597/files)


Before:
>% python s1_info.py S1B_IW_SLC__1SDV_20211222T054456_20211222T054526_030134_039920_9391.zip --frame-bbox 
Found 1 Sentinel-1 SLC products.
S1B_IW_SLC__1SDV_20211222T054456_20211222T054526_030134_039920_9391.zip: [-177.710968, 50.39941, 179.223694, 52.575905]

After:
>% python s1_info.py S1B_IW_SLC__1SDV_20211222T054456_20211222T054526_030134_039920_9391.zip --frame-bbox 
Found 1 Sentinel-1 SLC products.
S1B_IW_SLC__1SDV_20211222T054456_20211222T054526_030134_039920_9391.zip: [178.642044, 50.39941, 182.728027, 52.575905]