### PR TITLE
Patch for "no polynomial" case for azimuth FM rate mitigation & handling the burst without burst polygon

### DIFF
--- a/src/s1reader/s1_annotation.py
+++ b/src/s1reader/s1_annotation.py
@@ -1246,6 +1246,20 @@ class BurstExtendedCoeffs:
 
         # Scale factor to convert range (in meters) to seconds (tau)
         range_to_tau = 2.0 / speed_of_light
+
+        # Take care of the case when the az. time of the polynomial list does not cover
+        # the sensing start/stop
+        if index_end == index_start:
+            #      0--1--2--3--4--5 <- az. time of polynomial list (index shown on the left)
+            #|--|                   <- sensing start / stop
+            if index_start == 0:
+                index_end += 1
+
+            # 0--1--2--3--4--5      <- az. time of polynomial list (index shown on the left)
+            #                  |--| <- sensing start / stop
+            else:
+                index_start -= 1
+
         for poly in polynomial_list[index_start:index_end+1]:
             vec_aztime_sequence.append(poly[0])
             arr_coeff_sequence.append(poly[1].coeffs)

--- a/src/s1reader/s1_annotation.py
+++ b/src/s1reader/s1_annotation.py
@@ -1180,13 +1180,15 @@ class BurstExtendedCoeffs:
          fm_rate_coeff_burst_arr,
          fm_rate_tau0_burst_vec) = cls.extract_polynomial_sequence(az_fm_rate_list,
                                                                    sensing_start,
-                                                                   sensing_end)
+                                                                   sensing_end,
+                                                                   handle_out_of_range=True)
 
         (dc_aztime_burst_vec,
          dc_coeff_burst_arr,
          dc_tau0_burst_vec) = cls.extract_polynomial_sequence(doppler_centroid_list,
                                                               sensing_start,
-                                                              sensing_end)
+                                                              sensing_end,
+                                                              handle_out_of_range=True)
 
         return cls(fm_rate_aztime_burst_vec, fm_rate_coeff_burst_arr, fm_rate_tau0_burst_vec,
                    dc_aztime_burst_vec, dc_coeff_burst_arr, dc_tau0_burst_vec)
@@ -1195,7 +1197,8 @@ class BurstExtendedCoeffs:
     @classmethod
     def extract_polynomial_sequence(cls, polynomial_list: list,
                                     datetime_start: datetime.datetime,
-                                    datetime_end: datetime.datetime):
+                                    datetime_end: datetime.datetime,
+                                    handle_out_of_range=True):
         '''
         Scan `vec_azimuth_time` end find indices of the vector
         that covers the period defined with
@@ -1249,7 +1252,7 @@ class BurstExtendedCoeffs:
 
         # Take care of the case when the az. time of the polynomial list does not cover
         # the sensing start/stop
-        if index_end == index_start:
+        if (index_end == index_start) and handle_out_of_range:
             #      0--1--2--3--4--5 <- az. time of polynomial list (index shown on the left)
             #|--|                   <- sensing start / stop
             if index_start == 0:

--- a/src/s1reader/s1_burst_slc.py
+++ b/src/s1reader/s1_burst_slc.py
@@ -912,6 +912,9 @@ class Sentinel1BurstSlc:
 
         # calculate splined interpolation of the coeffs. and tau_0s
         if len(fm_rate_aztime_sec_vec) <= 1:
+            # Interpolator object cannot be created with only one set of polynomials.
+            # Such case happens when there is no polygon that falls between a burst's start / stop
+            # Return an empty LUT2d in that case
             return isce3.core.LUT2d()
         interpolator_tau0_ka = InterpolatedUnivariateSpline(
                                         fm_rate_aztime_sec_vec,
@@ -921,6 +924,9 @@ class Sentinel1BurstSlc:
         tau0_ka_interp = interpolator_tau0_ka(vec_t)[..., np.newaxis]
 
         if len(dc_aztime_sec_vec) <=1:
+            # Interpolator object cannot be created with only one set of polynomials.
+            # Such case happens when there is no polygon that falls between a burst's start / stop
+            # Return an empty LUT2d in that case
             return isce3.core.LUT2d()
         interpolator_tau0_fdc_interp = InterpolatedUnivariateSpline(
                                         dc_aztime_sec_vec,

--- a/src/s1reader/s1_burst_slc.py
+++ b/src/s1reader/s1_burst_slc.py
@@ -914,12 +914,14 @@ class Sentinel1BurstSlc:
         interpolator_tau0_ka = InterpolatedUnivariateSpline(
                                         fm_rate_aztime_sec_vec,
                                         self.extended_coeffs.fm_rate_tau0_vec,
+                                        ext=3,
                                         k=1)
         tau0_ka_interp = interpolator_tau0_ka(vec_t)[..., np.newaxis]
 
         interpolator_tau0_fdc_interp = InterpolatedUnivariateSpline(
                                         dc_aztime_sec_vec,
                                         self.extended_coeffs.dc_tau0_vec,
+                                        ext=3,
                                         k=1)
         tau0_fdc_interp = interpolator_tau0_fdc_interp(vec_t)[..., np.newaxis]
 

--- a/src/s1reader/s1_burst_slc.py
+++ b/src/s1reader/s1_burst_slc.py
@@ -911,6 +911,8 @@ class Sentinel1BurstSlc:
                              for datetime_vec in self.extended_coeffs.dc_aztime_vec]
 
         # calculate splined interpolation of the coeffs. and tau_0s
+        if len(fm_rate_aztime_sec_vec) <=1:
+            return isce3.core.LUT2d()
         interpolator_tau0_ka = InterpolatedUnivariateSpline(
                                         fm_rate_aztime_sec_vec,
                                         self.extended_coeffs.fm_rate_tau0_vec,
@@ -918,6 +920,8 @@ class Sentinel1BurstSlc:
                                         k=1)
         tau0_ka_interp = interpolator_tau0_ka(vec_t)[..., np.newaxis]
 
+        if len(dc_aztime_sec_vec) <=1:
+            return isce3.core.LUT2d()
         interpolator_tau0_fdc_interp = InterpolatedUnivariateSpline(
                                         dc_aztime_sec_vec,
                                         self.extended_coeffs.dc_tau0_vec,

--- a/src/s1reader/s1_burst_slc.py
+++ b/src/s1reader/s1_burst_slc.py
@@ -914,6 +914,7 @@ class Sentinel1BurstSlc:
         if len(fm_rate_aztime_sec_vec) <= 1:
             # Interpolator object cannot be created with only one set of polynomials.
             # Such case happens when there is no polygon that falls between a burst's start / stop
+            # which was found from very few Sentinel-1 IW SLCs processed by IPF 002.36
             # Return an empty LUT2d in that case
             return isce3.core.LUT2d()
         interpolator_tau0_ka = InterpolatedUnivariateSpline(
@@ -926,6 +927,7 @@ class Sentinel1BurstSlc:
         if len(dc_aztime_sec_vec) <=1:
             # Interpolator object cannot be created with only one set of polynomials.
             # Such case happens when there is no polygon that falls between a burst's start / stop
+            # which was found from very few Sentinel-1 IW SLCs processed by IPF 002.36
             # Return an empty LUT2d in that case
             return isce3.core.LUT2d()
         interpolator_tau0_fdc_interp = InterpolatedUnivariateSpline(

--- a/src/s1reader/s1_burst_slc.py
+++ b/src/s1reader/s1_burst_slc.py
@@ -911,7 +911,7 @@ class Sentinel1BurstSlc:
                              for datetime_vec in self.extended_coeffs.dc_aztime_vec]
 
         # calculate splined interpolation of the coeffs. and tau_0s
-        if len(fm_rate_aztime_sec_vec) <=1:
+        if len(fm_rate_aztime_sec_vec) <= 1:
             return isce3.core.LUT2d()
         interpolator_tau0_ka = InterpolatedUnivariateSpline(
                                         fm_rate_aztime_sec_vec,

--- a/src/s1reader/s1_reader.py
+++ b/src/s1reader/s1_reader.py
@@ -14,13 +14,12 @@ from packaging import version
 import isce3
 import numpy as np
 import shapely
-from shapely.affinity import translate 
 
 from scipy.interpolate import InterpolatedUnivariateSpline
 from nisar.workflows.stage_dem import check_dateline
 
 from s1reader import s1_annotation  # to access __file__
-from s1reader.s1_annotation import (RFI_INFO_AVAILABLE_FROM, 
+from s1reader.s1_annotation import (RFI_INFO_AVAILABLE_FROM,
                                     CalibrationAnnotation,
                                     AuxCal, BurstCalibration,
                                     BurstEAP, BurstNoise, BurstExtendedCoeffs,

--- a/src/s1reader/s1_reader.py
+++ b/src/s1reader/s1_reader.py
@@ -286,8 +286,8 @@ def get_burst_centers_and_boundaries(tree, num_bursts=None):
         warnings.warn('Inconsistency between # bursts in subswath, and the # polygons. ')
         num_missing_polygons = num_bursts - num_border_polygon
 
-        center_pts += [None] * num_missing_polygons
-        boundary_pts += [None] * num_missing_polygons
+        center_pts += [shapely.Point()] * num_missing_polygons
+        boundary_pts += [[shapely.Polygon()]] * num_missing_polygons
 
     return center_pts, boundary_pts
 

--- a/src/s1reader/s1_reader.py
+++ b/src/s1reader/s1_reader.py
@@ -240,7 +240,7 @@ def get_burst_centers_and_boundaries(tree, num_bursts=None):
         List of burst centroids ass shapely Points
     boundary_pts : list
         List of burst boundaries as shapely Polygons
-    '''    
+    '''
     # find element tree
     grid_pt_list = tree.find('geolocationGrid/geolocationGridPointList')
 

--- a/src/s1reader/version.py
+++ b/src/s1reader/version.py
@@ -4,6 +4,7 @@ import collections
 # release history
 Tag = collections.namedtuple('Tag', 'version date')
 release_history = (
+    Tag('0.2.3', '2023-09-21'),
     Tag('0.2.2', '2023-09-08'),
     Tag('0.2.1', '2023-08-23'),
     Tag('0.2.0', '2023-07-25'),


### PR DESCRIPTION
This PR is an attempt to fix the rare case that the list pf polynomials (azimuth FM rate or doppler centroid) does not have any overlap with the sensing start / stop of the burst. In that case, the azimuth FM rate mismatch correction finds the nearest polynomials in azimuth time, but the indices for polynomials (`index_start` and `index_end`) has the same value. When that happens interpolator from `InterpolatedUnivariateSpline` cannot be generated.

When that happens, the `index_start` and `index_end` are adjusted so that an`InterpolatedUnivariateSpline` gets to have valid parameters to create the interpolator.
When using the generated interpolator, optional parameter `ext=3` was set so that the interpolator returns the values at the left / right boundary values when the input parameter for the interpolation of out of range. This is equivalent to nearest neighbor in this case because the sensing start / stop is "out of range" from the list of polynomials' azimuth time.

Another issue that this PR handles is the when the burst does not have corresponding burst polygon. Such cases have been discovered as documented in #118. When that is the case, s1-reader will fill `Sentinel1BurstSlc.border` member with empty polygon. Likewise `Sentinel1BurstSlc.center` will be populated by an empty point geometry.