### PR TITLE
Add support for ASF-extracted burst SLC products

### DIFF
--- a/src/s1reader/__init__.py
+++ b/src/s1reader/__init__.py
@@ -3,5 +3,5 @@ from s1reader.version import release_version as __version__
 
 # top-level functions to be easily used
 from s1reader.s1_burst_slc import Sentinel1BurstSlc
-from s1reader.s1_reader import load_bursts
+from s1reader.s1_reader import load_bursts, load_single_burst
 from s1reader.s1_orbit import get_orbit_file_from_dir

--- a/src/s1reader/s1_burst_slc.py
+++ b/src/s1reader/s1_burst_slc.py
@@ -1,5 +1,5 @@
 import os
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 import datetime
 from lxml import etree
 import tempfile
@@ -209,7 +209,7 @@ class Doppler:
     poly1d: isce3.core.Poly1d
     lut2d: isce3.core.LUT2d
 
-@dataclass(frozen=False)
+@dataclass(frozen=True)
 class Sentinel1BurstSlc:
     '''Raw values extracted from SAFE XML.
     '''

--- a/src/s1reader/s1_burst_slc.py
+++ b/src/s1reader/s1_burst_slc.py
@@ -1,7 +1,7 @@
 import os
 from dataclasses import dataclass
 import datetime
-from lxml import etree
+import lxml.etree as ET
 import tempfile
 from typing import Optional
 import warnings
@@ -397,20 +397,20 @@ class Sentinel1BurstSlc:
         fulllength = gdal_obj.RasterYSize
         using_extracted_burst = fulllength == outlength and fullwidth == outwidth
 
-        vrt_dataset = etree.Element('VRTDataset', rasterXSize=str(outwidth), rasterYSize=str(outlength))
-        vrt_raster_band = etree.SubElement(vrt_dataset, 'VRTRasterBand', dataType='CFloat32', band='1')
-        no_data_value = etree.SubElement(vrt_raster_band, 'NoDataValue')
+        vrt_dataset = ET.Element('VRTDataset', rasterXSize=str(outwidth), rasterYSize=str(outlength))
+        vrt_raster_band = ET.SubElement(vrt_dataset, 'VRTRasterBand', dataType='CFloat32', band='1')
+        no_data_value = ET.SubElement(vrt_raster_band, 'NoDataValue')
         no_data_value.text = '0.0'
-        simple_source = etree.SubElement(vrt_raster_band, 'SimpleSource')
-        source_filename = etree.SubElement(simple_source, 'SourceFilename', relativeToVRT='1')
+        simple_source = ET.SubElement(vrt_raster_band, 'SimpleSource')
+        source_filename = ET.SubElement(simple_source, 'SourceFilename', relativeToVRT='1')
         source_filename.text = self.tiff_path
-        source_band = etree.SubElement(simple_source, 'SourceBand')
+        source_band = ET.SubElement(simple_source, 'SourceBand')
         source_band.text = '1'
         if not using_extracted_burst:
-            etree.SubElement(simple_source, 'SourceProperties', RasterXSize=str(fullwidth), RasterYSize=str(fulllength), DataType='CInt16')
-            etree.SubElement(simple_source, 'SrcRect', xOff=str(xoffset), yOff=str(yoffset), xSize=str(inwidth), ySize=str(inlength))
-            etree.SubElement(simple_source, 'DstRect', xOff=str(xoffset), yOff=str(localyoffset), xSize=str(inwidth), ySize=str(inlength))
-        tree = etree.ElementTree(vrt_dataset)
+            ET.SubElement(simple_source, 'SourceProperties', RasterXSize=str(fullwidth), RasterYSize=str(fulllength), DataType='CInt16')
+            ET.SubElement(simple_source, 'SrcRect', xOff=str(xoffset), yOff=str(yoffset), xSize=str(inwidth), ySize=str(inlength))
+            ET.SubElement(simple_source, 'DstRect', xOff=str(xoffset), yOff=str(localyoffset), xSize=str(inwidth), ySize=str(inlength))
+        tree = ET.ElementTree(vrt_dataset)
         tree.write(out_path, pretty_print=True, xml_declaration=False, encoding='utf-8')
 
     def get_az_carrier_poly(self, offset=0.0, xstep=500, ystep=50,

--- a/src/s1reader/s1_burst_slc.py
+++ b/src/s1reader/s1_burst_slc.py
@@ -384,8 +384,6 @@ class Sentinel1BurstSlc:
             warnings.warn(warn_str)
             return
 
-        absolute_path = os.path.join(os.getcwd(), self.tiff_path)
-
         line_offset = self.i_burst * self.shape[0]
 
         inwidth = self.last_valid_sample - self.first_valid_sample + 1
@@ -404,8 +402,8 @@ class Sentinel1BurstSlc:
         no_data_value = etree.SubElement(vrt_raster_band, 'NoDataValue')
         no_data_value.text = '0.0'
         simple_source = etree.SubElement(vrt_raster_band, 'SimpleSource')
-        source_filename = etree.SubElement(simple_source, 'SourceFilename', relativeToVRT='0')
-        source_filename.text = absolute_path
+        source_filename = etree.SubElement(simple_source, 'SourceFilename', relativeToVRT='1')
+        source_filename.text = self.tiff_path
         source_band = etree.SubElement(simple_source, 'SourceBand')
         source_band.text = '1'
         if not using_extracted_burst:

--- a/src/s1reader/s1_burst_slc.py
+++ b/src/s1reader/s1_burst_slc.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 import datetime
 import lxml.etree as ET
 import tempfile
+from pathlib import Path
 from typing import Optional
 import warnings
 
@@ -402,8 +403,8 @@ class Sentinel1BurstSlc:
         no_data_value = ET.SubElement(vrt_raster_band, 'NoDataValue')
         no_data_value.text = '0.0'
         simple_source = ET.SubElement(vrt_raster_band, 'SimpleSource')
-        source_filename = ET.SubElement(simple_source, 'SourceFilename', relativeToVRT='1')
-        source_filename.text = self.tiff_path
+        source_filename = ET.SubElement(simple_source, 'SourceFilename', relativeToVRT='0')
+        source_filename.text = str(Path(self.tiff_path).resolve())
         source_band = ET.SubElement(simple_source, 'SourceBand')
         source_band.text = '1'
         if not using_extracted_burst:

--- a/src/s1reader/s1_reader.py
+++ b/src/s1reader/s1_reader.py
@@ -966,8 +966,33 @@ def burst_from_combined_xml(tiff_path: str, metadata_path, orbit_path: str, flag
     burst = [x for x in bursts if str(x.burst_id)[5:] == short_id and x.polarization == pol][0]
     return burst
 
-def _bursts_from_et(annotation_et, iw2_annotation_et, manifest_et, annotation_datasets,
-                    orbit_path, tiff_path, safe_filename):
+def _bursts_from_et(annotation_et: ET.Element, iw2_annotation_et: ET.Element, manifest_et: ET.Element, annotation_datasets: dict,
+                    orbit_path: str, tiff_path: str, safe_filename: str):
+    '''Combine loaded Sentinel-1 SLC metadata into list of Sentinel1BurstSlc objects.
+
+    Parameters:
+    -----------
+    annotation_et : ET.Element
+        Element representing a bursts's annotation file.
+    iw2_annotation_et : ET.Element
+        Element representing a bursts's associated IW2 annoation file.
+    manifest_et : ET.Element
+        Element representing a bursts's associated manifest file.
+    annotation_datasets : dict
+        dictionary containing the various loaded Annotation* classes.
+    orbit_path : str
+        Path to orbit file.
+    tiff_path : str
+        Path to SLC tiff.
+    safe_file : str
+        Name of the bursts's parent SAFE file.
+
+    Returns:
+    --------
+    bursts : list
+        List of Sentinel1BurstSlc objects found in annotation XML.
+    '''
+ 
     ipf_version = get_ipf_version(manifest_et)
     # Parse out the start/end track to determine if we have an
     # equator crossing (for the burst_id calculation).

--- a/src/s1reader/s1_reader.py
+++ b/src/s1reader/s1_reader.py
@@ -771,10 +771,6 @@ def burst_from_xml(annotation_path: str, orbit_path: str, tiff_path: str,
                               f" >= {RFI_INFO_AVAILABLE_FROM}), but not loaded.")
             burst_rfi_info_swath = None
 
-        # Load the miscellaneous metadata for CARD4L-NRB
-        swath_misc_metadata = get_swath_misc_metadata(tree_manifest,
-                                                      tree_lads,
-                                                      product_annotation)
 
     with open_method(iw2_annotation_path, 'r') as iw2_f:
         tree_lads2 = ET.parse(iw2_f)
@@ -827,17 +823,19 @@ def burst_from_xml(annotation_path: str, orbit_path: str, tiff_path: str,
         aux_cal_subswath = None
     
     bursts = _bursts_from_et(tree_lads, tree_lads2, tree_manifest, calibration_annotation, noise_annotation,
-                             aux_cal_subswath, orbit_path, tiff_path, burst_rfi_info_swath, swath_misc_metadata, safe_filename)
+                             aux_cal_subswath, orbit_path, tiff_path, burst_rfi_info_swath, safe_filename)
     return  bursts
 
 def _bursts_from_et(annotation_et, iw2_annotation_et, manifest_et, calibration_annotation, noise_annotation,
-                    aux_cal_subswath, orbit_path, tiff_path, burst_rfi_info_swath, swath_misc_metadata, safe_filename):
+                    aux_cal_subswath, orbit_path, tiff_path, burst_rfi_info_swath, safe_filename):
     # Forrest Added
     ipf_version = get_ipf_version(manifest_et)
     # Parse out the start/end track to determine if we have an
     # equator crossing (for the burst_id calculation).
     start_track, end_track = get_start_end_track(manifest_et)
     product_annotation = ProductAnnotation.from_et(annotation_et)
+    # Load the miscellaneous metadata for CARD4L-NRB
+    swath_misc_metadata = get_swath_misc_metadata(manifest_et, annotation_et, product_annotation)
     
     platform_id = annotation_et.find('adsHeader/missionId').text.upper()
     subswath = annotation_et.find('adsHeader/swath').text.upper()

--- a/src/s1reader/s1_reader.py
+++ b/src/s1reader/s1_reader.py
@@ -909,7 +909,7 @@ def burst_from_combined_xml(tiff_path: str, metadata_path, orbit_path: str, flag
     tree_lads2 = get_subxml_from_burst_metadata(tree_metadata, 'product', 'IW2', pol)[1]
 
     # Load RFI information if available
-    tree_rads = get_subxml_from_burst_metadata(tree_metadata, 'product', subswath, pol)[1]
+    tree_rads = get_subxml_from_burst_metadata(tree_metadata, 'rfi', subswath, pol)[1]
     if tree_rads is not None:
         annotation_datasets['burst_rfi_info_swath'] = SwathRfiInfo.from_et(tree_rads,
                                                     tree_lads,

--- a/src/s1reader/s1_reader.py
+++ b/src/s1reader/s1_reader.py
@@ -922,7 +922,7 @@ def burst_from_combined_xml(tiff_path: str, metadata_path, orbit_path: str, flag
 
     # load the Calibraton annotation
     tree_cads = get_subxml_from_burst_metadata(tree_metadata, 'calibration', subswath, pol)[1]
-    if tree_rads is not None:
+    if tree_cads is not None:
         annotation_datasets['calibration_annotation'] = CalibrationAnnotation.from_et(tree_cads, '')
     else:
         annotation_datasets['calibration_annotation'] = None

--- a/src/s1reader/s1_reader.py
+++ b/src/s1reader/s1_reader.py
@@ -851,7 +851,7 @@ def get_subxml_from_burst_metadata(metadata, xml_type, subswath=None, polarizati
     return desired_metadata
     
 
-def burst_from_combined_xml(tiff_path: str, metadata_path, orbit_path: str, open_method=open, flag_apply_eap: bool = True, is_asf_burst: bool = False):
+def burst_from_combined_xml(tiff_path: str, metadata_path, orbit_path: str, open_method=open, flag_apply_eap: bool = True):
     '''Parse bursts in Sentinel-1 annotation XML.
 
     Parameters:
@@ -951,12 +951,12 @@ def burst_from_combined_xml(tiff_path: str, metadata_path, orbit_path: str, open
     annotation_datasets['aux_cal_subswath'] = None
     
     bursts = _bursts_from_et(tree_lads, tree_lads2, tree_manifest, annotation_datasets, 
-                             orbit_path, tiff_path, None, is_asf_burst=is_asf_burst)
+                             orbit_path, tiff_path, None)
 
     return  bursts
 
 def _bursts_from_et(annotation_et, iw2_annotation_et, manifest_et, annotation_datasets,
-                    orbit_path, tiff_path, safe_filename, is_asf_burst = False):
+                    orbit_path, tiff_path, safe_filename):
     ipf_version = get_ipf_version(manifest_et)
     # Parse out the start/end track to determine if we have an
     # equator crossing (for the burst_id calculation).
@@ -1167,7 +1167,7 @@ def _bursts_from_et(annotation_et, iw2_annotation_et, manifest_et, annotation_da
                                       range_window_type, range_window_coeff,
                                       rank, prf_raw_data, range_chirp_ramp_rate,
                                       burst_calibration, burst_noise, burst_aux_cal,
-                                      extended_coeffs, burst_rfi_info, burst_misc_metadata, is_asf_burst)
+                                      extended_coeffs, burst_rfi_info, burst_misc_metadata)
 
     return bursts
 
@@ -1201,7 +1201,7 @@ def load_single_burst(data_path, metadata_path, orbit_path):
     if not os.path.exists(orbit_path):
         raise FileNotFoundError(f'{orbit_path} not found')
 
-    bursts = burst_from_combined_xml(data_path, metadata_path, orbit_path, is_asf_burst=True)
+    bursts = burst_from_combined_xml(data_path, metadata_path, orbit_path)
 
     short_id = '_'.join(os.path.basename(data_path).split('_')[1:3]).lower()
     desired_burst = [x for x in bursts if str(x.burst_id)[5:] == short_id][0]

--- a/src/s1reader/s1_reader.py
+++ b/src/s1reader/s1_reader.py
@@ -851,7 +851,7 @@ def get_subxml_from_burst_metadata(metadata, xml_type, subswath=None, polarizati
     return desired_metadata
     
 
-def burst_from_combined_xml(tiff_path: str, metadata_path, orbit_path: str, open_method=open, flag_apply_eap: bool = True):
+def burst_from_combined_xml(tiff_path: str, metadata_path, orbit_path: str, open_method=open, flag_apply_eap: bool = True, is_asf_burst: bool = False):
     '''Parse bursts in Sentinel-1 annotation XML.
 
     Parameters:
@@ -951,12 +951,12 @@ def burst_from_combined_xml(tiff_path: str, metadata_path, orbit_path: str, open
     annotation_datasets['aux_cal_subswath'] = None
     
     bursts = _bursts_from_et(tree_lads, tree_lads2, tree_manifest, annotation_datasets, 
-                             orbit_path, tiff_path, None)
+                             orbit_path, tiff_path, None, is_asf_burst=is_asf_burst)
 
     return  bursts
 
 def _bursts_from_et(annotation_et, iw2_annotation_et, manifest_et, annotation_datasets,
-                    orbit_path, tiff_path, safe_filename):
+                    orbit_path, tiff_path, safe_filename, is_asf_burst = False):
     ipf_version = get_ipf_version(manifest_et)
     # Parse out the start/end track to determine if we have an
     # equator crossing (for the burst_id calculation).
@@ -1167,7 +1167,7 @@ def _bursts_from_et(annotation_et, iw2_annotation_et, manifest_et, annotation_da
                                       range_window_type, range_window_coeff,
                                       rank, prf_raw_data, range_chirp_ramp_rate,
                                       burst_calibration, burst_noise, burst_aux_cal,
-                                      extended_coeffs, burst_rfi_info, burst_misc_metadata)
+                                      extended_coeffs, burst_rfi_info, burst_misc_metadata, is_asf_burst)
 
     return bursts
 
@@ -1201,7 +1201,7 @@ def load_single_burst(data_path, metadata_path, orbit_path):
     if not os.path.exists(orbit_path):
         raise FileNotFoundError(f'{orbit_path} not found')
 
-    bursts = burst_from_combined_xml(data_path, metadata_path, orbit_path)
+    bursts = burst_from_combined_xml(data_path, metadata_path, orbit_path, is_asf_burst=True)
 
     short_id = '_'.join(os.path.basename(data_path).split('_')[1:3]).lower()
     desired_burst = [x for x in bursts if str(x.burst_id)[5:] == short_id][0]


### PR DESCRIPTION
ASF has been working to provide users the capability to download [single-burst Sentinel-1 SLC data](https://asf.alaska.edu/datasets/data-sets/derived-data-sets/sentinel-1-bursts/). This PR adds support for these products to `s1-reader`, allowing users to load an ASF-extracted burst SLC product as a `Sentinel1BurstSlc` object.

To add this functionality, I've made the following modifications:

- `s1_reader.load_from_xml` was split into two functions; one function that loads data lxml objects (`load_from_xml`), and a new function that parses the data from these objects (`_bursts_from_et`)
- Modified arguments of `s1_reader.get_path_aux_cal` so that it takes `platform_id` and `sensing_start` as arguments instead of `annotation_path`
- Added `s1_reader.get_subxml_from_burst_metadata` which extracts a desired metadata file from a combined XML file
- Added `s1_reader.burst_from_combined_xml` which creates a `Sentinel1BurstSlc` object from combined XML data
- Added `s1_reader.load_single_burst` as a user-facing function for load an ASF-extracted burst
- Modified `s1_burst_slc.Sentinel1BurstSlc.slc_to_vrt_file` so that it uses lxml to create VRTs and so that it skips the subsetting of the SLC data if it is working with an extracted burst tiff.

I imagine you all will have many code suggestions, formatting updates, and test additions, so please request that I make these changes, or feel free to add them yourself.