### PR TITLE
Read average azimuth pixel spacing from S1 annotation files

### DIFF
--- a/src/s1reader/s1_annotation.py
+++ b/src/s1reader/s1_annotation.py
@@ -454,9 +454,6 @@ class ProductAnnotation(AnnotationBase):
         cls.number_of_samples = \
             cls._parse_scalar('imageAnnotation/imageInformation/numberOfSamples',
                               'scalar_int')
-        cls.number_of_samples = \
-            cls._parse_scalar('imageAnnotation/imageInformation/numberOfSamples',
-                              'scalar_int')
         cls.range_sampling_rate = \
             cls._parse_scalar('generalAnnotation/productInformation/rangeSamplingRate',
                               'scalar_float')

--- a/src/s1reader/s1_burst_slc.py
+++ b/src/s1reader/s1_burst_slc.py
@@ -218,6 +218,7 @@ class Sentinel1BurstSlc:
     radar_center_frequency: float
     wavelength: float
     azimuth_steer_rate: float
+    average_azimuth_pixel_spacing: float
     azimuth_time_interval: float
     slant_range_time: float
     starting_range: float

--- a/src/s1reader/s1_reader.py
+++ b/src/s1reader/s1_reader.py
@@ -835,6 +835,7 @@ def burst_from_xml(annotation_path: str, orbit_path: str, tiff_path: str,
         orbit_direction = product_info_element.find('pass').text
 
         image_info_element = tree.find('imageAnnotation/imageInformation')
+        average_azimuth_pixel_spacing = float(image_info_element.find('azimuthPixelSpacing').text)
         azimuth_time_interval = float(image_info_element.find('azimuthTimeInterval').text)
         slant_range_time = float(image_info_element.find('slantRangeTime').text)
         ascending_node_time_annotation =\
@@ -1014,7 +1015,8 @@ def burst_from_xml(annotation_path: str, orbit_path: str, tiff_path: str,
         burst_misc_metadata = swath_misc_metadata.extract_by_aztime(sensing_start)
 
         bursts[i] = Sentinel1BurstSlc(ipf_version, sensing_start, radar_freq, wavelength,
-                                      azimuth_steer_rate, azimuth_time_interval,
+                                      azimuth_steer_rate, average_azimuth_pixel_spacing,
+                                      azimuth_time_interval,
                                       slant_range_time, starting_range, iw2_mid_range,
                                       range_sampling_rate, range_pxl_spacing,
                                       (n_lines, n_samples), az_fm_rate, doppler,

--- a/src/s1reader/version.py
+++ b/src/s1reader/version.py
@@ -4,6 +4,7 @@ import collections
 # release history
 Tag = collections.namedtuple('Tag', 'version date')
 release_history = (
+    Tag('0.2.4', '2024-03-11'),
     Tag('0.2.3', '2023-09-21'),
     Tag('0.2.2', '2023-09-08'),
     Tag('0.2.1', '2023-08-23'),

--- a/tests/test_bursts.py
+++ b/tests/test_bursts.py
@@ -38,6 +38,11 @@ def test_burst(bursts):
         assert burst.radar_center_frequency == 5405000454.33435
         assert burst.wavelength == 0.05546576
         assert burst.azimuth_steer_rate == 0.024389943375862838
+
+        # the average azimuth pixel spacing varies across bursts
+        assert burst.average_azimuth_pixel_spacing > 13.9
+        assert burst.average_azimuth_pixel_spacing < 14.0
+
         assert burst.starting_range == 901673.89084624
         assert burst.iw2_mid_range == 875604.926001518
         assert burst.range_sampling_rate == 64345238.12571428


### PR DESCRIPTION
This PR updates the S1-reader to parse the average azimuth pixel spacing from S1 annotation files and storing it as the `Sentinel1BurstSlc` class attribute `average_azimuth_pixel_spacing`. This field is required by CEOS ARD specifications for Normalized Radar Backscatter (NRB) products (e.g., the OPERA RTC-S1 product).

The PR also remove repeated code that reads the field `imageAnnotation/imageInformation/numberOfSamples` from S1 annotation files.