### PR TITLE
Fix .git-blame-ignore-revs for squashed commit hash

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,3 +1,3 @@
 # .git-blame-ignore-revs
 # Run ruff-format on codebase
-b3f11b8ab7814094a433ff23852bd1e52eb8bbbd
+a6d775f20a30479e9cc26f6f04bbbbcc2762da2e


### PR DESCRIPTION
The commit changed since we have "squash" on by default when merging PRs