### PR TITLE
bump version from `0.2.4->0.2.5`

### DIFF
--- a/src/s1reader/version.py
+++ b/src/s1reader/version.py
@@ -4,6 +4,7 @@ import collections
 # release history
 Tag = collections.namedtuple("Tag", "version date")
 release_history = (
+    Tag("0.2.5", "2025-05-01"),
     Tag("0.2.4", "2024-03-11"),
     Tag("0.2.3", "2023-09-21"),
     Tag("0.2.2", "2023-09-08"),


### PR DESCRIPTION
This PR is to bump the version of `s1reader` before cutting the release.